### PR TITLE
chore: remove upstreamed patches

### DIFF
--- a/patches
+++ b/patches
@@ -4,10 +4,6 @@ https://github.com/xing/act/pull/23.patch
 # customize goreleaser configuration
 https://github.com/xing/act/pull/22.patch
 # -------------------------------------------
-# feat: allow existing logger from context
-https://github.com/nektos/act/pull/898.patch
-# feat: read docker credentials from local docker config
-https://github.com/nektos/act/pull/891.patch
 # feat: try to read ref and sha from event payload if available
 https://github.com/nektos/act/pull/889.patch
 # fix: continue jobs + steps after failure


### PR DESCRIPTION
* https://github.com/nektos/act/pull/898
* https://github.com/nektos/act/pull/891

have both been merged upstream, so they're no longer required here.