### PR TITLE
patch: print plan summary upfront to executing it

### DIFF
--- a/pkg/runner/boundaries.go
+++ b/pkg/runner/boundaries.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
+	log "github.com/sirupsen/logrus"
+)
+
+func escapeID(id string) string {
+	id = strings.ReplaceAll(id, "|", "||")
+	id = strings.ReplaceAll(id, "\n", "\\n")
+	return id
+}
+
+func printPlan(plan *model.Plan) {
+	log.Debugln("################################################################################")
+	log.Debugf("# %s", plan.Stages[0].Runs[0].Workflow.Name)
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			log.Debugf("## %s | %s", escapeID(run.JobID), run.Job().Name)
+			for n, step := range run.Job().Steps {
+				id := step.ID
+				if id == "" {
+					id = fmt.Sprint(n)
+				}
+
+				log.Debugf("### %s | %s", escapeID(id), step)
+			}
+		}
+	}
+	log.Debugln("################################################################################")
+}
+
+func (rc *RunContext) logJobBoundaries(executor common.Executor) common.Executor {
+	id := escapeID(rc.Run.JobID)
+	jobName := escapeID(rc.JobName)
+
+	return common.NewDebugExecutor("@@ job | start | %s | %s @@", id, jobName).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			jobStatus := rc.getJobContext().Status
+			return common.NewDebugExecutor("@@ job | stop | %s | %s | %s @@", id, jobName, jobStatus)(ctx)
+		})
+}
+
+func (rc *RunContext) logStepBoundaries(step *model.Step, executor common.Executor) common.Executor {
+	id := escapeID(step.ID)
+	stepIdentifier := escapeID(step.String())
+
+	return common.NewDebugExecutor("@@ step | start | %s | %s @@", id, stepIdentifier).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			result := rc.StepResults[step.ID]
+			var stepStatus string
+			if result != nil {
+				stepStatus = result.Conclusion.String()
+			} else {
+				stepStatus = "unknown"
+			}
+			return common.NewDebugExecutor("@@ step | stop | %s | %s | %s @@", id, stepIdentifier, stepStatus)(ctx)
+		})
+}

--- a/pkg/runner/boundaries.go
+++ b/pkg/runner/boundaries.go
@@ -23,6 +23,9 @@ func printPlan(plan *model.Plan) {
 		for _, run := range stage.Runs {
 			log.Debugf("## %s | %s", escapeID(run.JobID), run.Job().Name)
 			for n, step := range run.Job().Steps {
+				if step == nil {
+					continue
+				}
 				id := step.ID
 				if id == "" {
 					id = fmt.Sprint(n)

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -52,7 +52,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		preSteps = append(preSteps, step.pre())
 
 		stepExec := step.main()
-		steps = append(steps, func(ctx context.Context) error {
+		steps = append(steps, rc.logStepBoundaries(stepModel, func(ctx context.Context) error {
 			stepName := stepModel.String()
 			return (func(ctx context.Context) error {
 				err := stepExec(ctx)
@@ -65,7 +65,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				}
 				return nil
 			})(withStepLogger(ctx, stepName))
-		})
+		}))
 
 		postSteps = append([]common.Executor{step.post()}, postSteps...)
 	}

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -53,7 +53,6 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 
 		stepExec := step.main()
 		steps = append(steps, rc.logStepBoundaries(stepModel, func(ctx context.Context) error {
-			stepName := stepModel.String()
 			return (func(ctx context.Context) error {
 				err := stepExec(ctx)
 				if err != nil {
@@ -64,7 +63,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 					common.SetJobError(ctx, ctx.Err())
 				}
 				return nil
-			})(withStepLogger(ctx, stepName))
+			})(withStepLogger(ctx, stepModel.ID, stepModel.String()))
 		}))
 
 		postSteps = append([]common.Executor{step.post()}, postSteps...)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -117,6 +117,8 @@ func New(runnerConfig *Config) (Runner, error) {
 }
 
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
+	printPlan(plan)
+
 	maxJobNameLen := 0
 
 	stagePipeline := make([]common.Executor, 0)
@@ -155,7 +157,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					}
 					stageExecutor = append(stageExecutor, func(ctx context.Context) error {
 						jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-						return rc.Executor().Finally(func(ctx context.Context) error {
+						return rc.logJobBoundaries(rc.Executor()).Finally(func(ctx context.Context) error {
 							isLastRunningContainer := func(currentStage int, currentRun int) bool {
 								return currentStage == len(plan.Stages)-1 && currentRun == len(stage.Runs)-1
 							}


### PR DESCRIPTION
This change will print a toc at debug level upfront to running
a workflow. It will help prepare outputs for (e.g. UI) before
executing and parsing the log output.

Co-authored-by: Philipp Hinrichsen <philipp.hinrichsen@new-work.se>
Co-authored-by: Björn Brauer <bjoern.brauer@new-work.se>