### PR TITLE
fix: revert patch for local cloning

### DIFF
--- a/patches
+++ b/patches
@@ -5,8 +5,6 @@ https://github.com/xing/act/pull/23.patch
 https://github.com/xing/act/pull/22.patch
 # feat: print plan summary upfront to executing it
 https://github.com/xing/act/pull/34.patch
-# check if org is actions/gh-actions for remoteAction.isCheckout
-https://github.com/xing/act/pull/38.patch
 # Revert "fix: add simple concurrency limit (#823)"
 https://github.com/xing/act/pull/36.patch
 # -------------------------------------------


### PR DESCRIPTION
Since we need to clone on the jenkins (this should match GitHub Actions behavior), we have to revert this patch.
A better way to do this would be to make it configurable via the act configuration. Either in upstream (prefered) or as  a local patch if not accepted upstream.