### PR TITLE
fix: use depth 0 to savely apply patches

### DIFF
--- a/.github/workflows/build-with-patches.yml
+++ b/.github/workflows/build-with-patches.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
       - name: setup git
         run: |
           git config --global user.name github-actions
@@ -49,6 +50,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+          fetch-depth: 0
       - name: setup git
         run: |
           git config --global user.name github-actions


### PR DESCRIPTION
with depth=1 previously set not all patches would apply cleanly.
this PR sets the clone depth to unlimited to solve the problem.

Co-authored-by: Björn Brauer <bjoern.brauer@new-work.se>
Co-authored-by: Markus Wolf <markus.wolf@new-work.se>