### PR TITLE
patch: print plan summary upfront to executing it (2)

### DIFF
--- a/pkg/runner/boundaries.go
+++ b/pkg/runner/boundaries.go
@@ -1,0 +1,69 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nektos/act/pkg/common"
+	"github.com/nektos/act/pkg/model"
+	log "github.com/sirupsen/logrus"
+)
+
+func escapeID(id string) string {
+	id = strings.ReplaceAll(id, "|", "||")
+	id = strings.ReplaceAll(id, "\n", "\\n")
+	return id
+}
+
+func printPlan(plan *model.Plan) {
+	log.Debugln("################################################################################")
+	log.Debugf("# %s", plan.Stages[0].Runs[0].Workflow.Name)
+	for _, stage := range plan.Stages {
+		for _, run := range stage.Runs {
+			log.Debugf("## %s | %s", escapeID(run.JobID), run.Job().Name)
+			for n, step := range run.Job().Steps {
+				if step == nil {
+					continue
+				}
+				id := step.ID
+				if id == "" {
+					id = fmt.Sprint(n)
+				}
+
+				log.Debugf("### %s | %s", escapeID(id), step)
+			}
+		}
+	}
+	log.Debugln("################################################################################")
+}
+
+func (rc *RunContext) logJobBoundaries(executor common.Executor) common.Executor {
+	id := escapeID(rc.Run.JobID)
+	jobName := escapeID(rc.JobName)
+
+	return common.NewDebugExecutor("@@ job | start | %s | %s @@", id, jobName).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			jobStatus := rc.getJobContext().Status
+			return common.NewDebugExecutor("@@ job | stop | %s | %s | %s @@", id, jobName, jobStatus)(ctx)
+		})
+}
+
+func (rc *RunContext) logStepBoundaries(step *model.Step, executor common.Executor) common.Executor {
+	id := escapeID(step.ID)
+	stepIdentifier := escapeID(step.String())
+
+	return common.NewDebugExecutor("@@ step | start | %s | %s @@", id, stepIdentifier).
+		Then(executor).
+		Finally(func(ctx context.Context) error {
+			result := rc.StepResults[step.ID]
+			var stepStatus string
+			if result != nil {
+				stepStatus = result.Conclusion.String()
+			} else {
+				stepStatus = "unknown"
+			}
+			return common.NewDebugExecutor("@@ step | stop | %s | %s | %s @@", id, stepIdentifier, stepStatus)(ctx)
+		})
+}

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nektos/act/pkg/common"
 	"github.com/nektos/act/pkg/model"
+	"github.com/sirupsen/logrus"
 )
 
 type jobInfo interface {
@@ -113,7 +114,10 @@ func useStepLogger(rc *RunContext, stepModel *model.Step, stage stepStage, execu
 	return func(ctx context.Context) error {
 		ctx = withStepLogger(ctx, stepModel.ID, stepModel.String(), stage.String())
 
-		rawLogger := common.Logger(ctx).WithField("raw_output", true)
+		rawLogger := common.Logger(ctx).WithFields(logrus.Fields{
+			"raw_output": true,
+			"stage":      stage.String(),
+		})
 		logWriter := common.NewLineWriter(rc.commandHandler(ctx), func(s string) bool {
 			if rc.Config.LogOutput {
 				rawLogger.Infof("%s", s)

--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -60,7 +60,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 		preSteps = append(preSteps, useStepLogger(rc, stepModel, stepStagePre, step.pre()))
 
 		stepExec := step.main()
-		steps = append(steps, useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
+		steps = append(steps, rc.logStepBoundaries(stepModel, useStepLogger(rc, stepModel, stepStageMain, func(ctx context.Context) error {
 			logger := common.Logger(ctx)
 			err := stepExec(ctx)
 			if err != nil {
@@ -71,7 +71,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 				common.SetJobError(ctx, ctx.Err())
 			}
 			return nil
-		}))
+		})))
 
 		postExec := useStepLogger(rc, stepModel, stepStagePost, step.post())
 		if postExecutor != nil {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -121,6 +121,8 @@ func New(runnerConfig *Config) (Runner, error) {
 // NewPlanExecutor ...
 //nolint:gocyclo
 func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
+	printPlan(plan)
+
 	maxJobNameLen := 0
 
 	stagePipeline := make([]common.Executor, 0)
@@ -165,7 +167,7 @@ func (runner *runnerImpl) NewPlanExecutor(plan *model.Plan) common.Executor {
 					stageExecutor = append(stageExecutor, func(ctx context.Context) error {
 						logger := common.Logger(ctx)
 						jobName := fmt.Sprintf("%-*s", maxJobNameLen, rc.String())
-						return rc.Executor().Finally(func(ctx context.Context) error {
+						return rc.logJobBoundaries(rc.Executor()).Finally(func(ctx context.Context) error {
 							isLastRunningContainer := func(currentStage int, currentRun int) bool {
 								return currentStage == len(plan.Stages)-1 && currentRun == len(stage.Runs)-1
 							}


### PR DESCRIPTION
This change will print a toc at debug level upfront to running
a workflow. It will help prepare outputs for (e.g. UI) before
executing and parsing the log output.

- fix: handle nil steps
- refactor: prepare for improved logging update

Co-authored-by: Philipp Hinrichsen <philipp.hinrichsen@new-work.se>
Co-authored-by: Björn Brauer <bjoern.brauer@new-work.se>