### PR TITLE
fix: restore job logger for clean-up tasks after cancellation

### DIFF
--- a/pkg/runner/job_executor.go
+++ b/pkg/runner/job_executor.go
@@ -111,7 +111,7 @@ func newJobExecutor(info jobInfo, sf stepFactory, rc *RunContext) common.Executo
 			if ctx.Err() == context.Canceled {
 				// in case of an aborted run, we still should execute the
 				// post steps to allow cleanup.
-				ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+				ctx, cancel = context.WithTimeout(WithJobLogger(context.Background(), rc.Run.JobID, rc.String(), rc.Config, &rc.Masks), 5*time.Minute)
 				defer cancel()
 			}
 			return postExecutor(ctx)


### PR DESCRIPTION
Co-authored-by: Markus Wolf <markus.wolf@new-work.se>