### PR TITLE
chore: remove patch for plan summary

### DIFF
--- a/patches
+++ b/patches
@@ -4,7 +4,5 @@ https://github.com/xing/act/pull/23
 # customize goreleaser configuration
 https://github.com/xing/act/pull/22
 # -------------------------------------------
-# feat: print plan summary upfront to executing it
-https://github.com/xing/act/pull/53
 # fix: restore job logger for clean-up tasks after cancellation
 https://github.com/xing/act/pull/56


### PR DESCRIPTION
With our new json-based log parser, we don't need the plan summary.
