### PR TITLE
chore: update upstream patches

### DIFF
--- a/patches
+++ b/patches
@@ -4,5 +4,5 @@ https://github.com/xing/act/pull/23
 # customize goreleaser configuration
 https://github.com/xing/act/pull/22
 # -------------------------------------------
-# fix: correct ref and ref_name
-https://github.com/nektos/act/pull/1672
+# Revert breaking docker socket changes
+https://github.com/nektos/act/pull/1763


### PR DESCRIPTION
Removed a patch which was merged upstream and added a patch to restore docker socket handling.