### PR TITLE
chore: remove merged upstream PR patch

### DIFF
--- a/patches
+++ b/patches
@@ -4,5 +4,3 @@ https://github.com/xing/act/pull/23
 # customize goreleaser configuration
 https://github.com/xing/act/pull/22
 # -------------------------------------------
-# Revert breaking docker socket changes
-https://github.com/nektos/act/pull/1763


### PR DESCRIPTION
This PR has been merged upstream and is no longer neccessary.