### PR TITLE
test: raise timeout to 25min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ act-build: patch
 
 .PHONY: act-test
 act-test: patch
-	cd act && go test -v -timeout 15m ./...
+	cd act && go test -v -timeout 25m ./...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
current tests run 16min and test suite fails. see
https://github.com/xing/act/actions/runs/5243399549/jobs/9468043925